### PR TITLE
pySerial write() expects byte as argument

### DIFF
--- a/grabserial
+++ b/grabserial
@@ -399,7 +399,7 @@ def grab(arglist, outputfd=sys.stdout):
     sd.flushOutput()
 
     if command:
-        sd.write(command + "\n")
+        sd.write((command + "\n").encode())
         sd.flush()
 
     # capture stdin to send to serial port
@@ -412,7 +412,7 @@ def grab(arglist, outputfd=sys.stdout):
     while 1:
         try:
             if cmdinput:
-                sd.write(cmdinput + "\n")
+                sd.write((cmdinput + "\n").encode())
                 cmdinput = ""
 
             # read for up to 1 second


### PR DESCRIPTION
Fixes the following error on windows for me when typeing commands in a running grabserial instance or by passing via -c

Traceback (most recent call last):
  File "tools/python/grabserial.py", line 530, in <module>
    grab(sys.argv[1:])
  File "tools/python/grabserial.py", line 415, in grab
    sd.write(cmdinput + "\n")
  File "c:\gsPython\lib\site-packages\pyserial-3.4-py3.6.egg\serial\serialwin32.py", line 308, in write
    data = to_bytes(data)
  File "c:\gsPython\lib\site-packages\pyserial-3.4-py3.6.egg\serial\serialutil.py", line 63, in to_bytes
    raise TypeError('unicode strings are not supported, please encode to bytes: {!r}'.format(seq))
TypeError: unicode strings are not supported, please encode to bytes: 'run bl\n'